### PR TITLE
feature: increase access token from 5m => 1h

### DIFF
--- a/sep490-idp/src/main/resources/application.yml
+++ b/sep490-idp/src/main/resources/application.yml
@@ -18,6 +18,8 @@ spring:
                 - phone
             require-authorization-consent: false
             require-proof-key: true
+            token:
+              access-token-time-to-live: PT1H
   mail:
     host: ${SMTP_HOST:127.0.0.1}
     port: ${SMTP_PORT:1025}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the OAuth2 client configuration with a new token lifetime setting, establishing a default validity period of one hour for access tokens to improve security and token management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->